### PR TITLE
Fix `starlette.HrefMiddleware` not being compatible with lifespans

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Unreleased
 
 Fixed
  * Fixed JSON encoding error with recent FastAPI versions
+ * Fixed ``starlette.HrefMiddleware`` not being compatible with lifespans
 
 Deprecated
  * Python 3.7 is EOL. It is still allowed, but no longer tested.

--- a/hrefs/starlette.py
+++ b/hrefs/starlette.py
@@ -1,5 +1,6 @@
 """Starlette integration"""
 
+import contextlib
 import functools
 import itertools
 import typing
@@ -222,8 +223,12 @@ class HrefMiddleware:
         self.app = app
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send):
-        connection = HTTPConnection(scope)
-        with href_context(connection):
+        ctx: contextlib.AbstractContextManager
+        if scope["type"] in ("http", "websocket"):
+            ctx = href_context(HTTPConnection(scope))
+        else:
+            ctx = contextlib.nullcontext()
+        with ctx:
             await self.app(scope, receive, send)
 
 


### PR DESCRIPTION
Fixes https://github.com/jasujm/hrefs/issues/9